### PR TITLE
Changing potion phase model description

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -152,7 +152,7 @@ Upgrade Level | Multiplier Increase | Cost
 ## Game Item
 ### Power-Ups
 - Potion Magent, a potion bottle with a magnet symbol
-- Potion Phase, a potion bottle with boots symbol 
+- Potion Phase, a potion bottle with horizontal-wave symbol 
 - Potion Boost, a potion bottle with lightning symbol
 - Potion Guld, a potion bottle with Golden coin symbol
 

--- a/GDD.md
+++ b/GDD.md
@@ -152,7 +152,7 @@ Upgrade Level | Multiplier Increase | Cost
 ## Game Item
 ### Power-Ups
 - Potion Magent, a potion bottle with a magnet symbol
-- Potion Phase, a potion bottle with horizontal-wave symbol 
+- Potion Phase, a potion bottle with ghost symbol 
 - Potion Boost, a potion bottle with lightning symbol
 - Potion Guld, a potion bottle with Golden coin symbol
 


### PR DESCRIPTION
Changing the potion phase model description from boots which was irrelevant with phasing power into Ghost symbol because ghost symbolizing everything can get through a ghost like object